### PR TITLE
Add two OCTA datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,8 @@ These datasets form the foundation for training next-generation medical AI model
 | 22 | [Soltanian Optica 2021](https://people.duke.edu/~sf59/Soltanian_Optica_2021.htm) | 2021 | 3D | OCT | Retina | 8 | Yes | Seg | Glaucoma |
 | 23 | [STAGE](https://doi.org/10.5281/zenodo.7835341                  ) | 2023 | 3D | OCT | Retina | 400 | Yes | Reg/Cls | Glaucoma |
 | 24 | [Eye OCT Datasets](https://tianchi.aliyun.com/dataset/dataDetail?dataId=90672) | 2021 | 3D | OCT | Retina | 148 | Yes | Cls/Seg | Retinal diseases |
+| 25 | [OCTA-500](https://ieee-dataport.org/open-access/octa-500) | 2020 | 3D | OCTA | Retina | 500 | Yes | Seg/Image Translation | Retinal diseases |
+| 26 | [OCTA-2024](https://openaccess.thecvf.com/content/CVPR2025/papers/Chen_MuTri_Multi-view_Tri-alignment_for_OCT_to_OCTA_3D_Image_Translation_CVPR_2025_paper.pdf) | 2024 | 3D | OCTA | Retina | 846 | Yes | Image Translation | Retinal diseases |
 </details>
 
 ## 🎬 Video Medical Datasets


### PR DESCRIPTION
1. OCTA-500 dataset
Link: https://ieee-dataport.org/open-access/octa-500
Refer: Li, Mingchao, et al. "OCTA-500: a retinal dataset for optical coherence tomography angiography study." Medical image analysis 93 (2024): 103092.

2. OCTA2024 dataset
Code link: https://github.com/xmed-lab/MuTri
Need to contact the author to get access to the dataset.
Refer: Chen, Zhuangzhuang, et al. "MuTri: Multi-view Tri-alignment for OCT to OCTA 3D Image Translation." CVPR. 2025.